### PR TITLE
Update to ubuntu:noble and PHP 8.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #Dockerfile.
-FROM ubuntu:jammy
+FROM ubuntu:noble
 
 ARG DEBIAN_FRONTEND="noninteractive"
 
@@ -22,7 +22,7 @@ RUN sed -i -e 's/;\(clear_env\) = .*/\1 = no/i' \
 		-e 's/^\(user\|group\) = .*/\1 = app/i' \
 		-e 's/;\(php_admin_value\[error_log\]\) = .*/\1 = \/tmp\/error.log/' \
 		-e 's/;\(php_admin_flag\[log_errors\]\) = .*/\1 = on/' \
-        /etc/php/8.1/fpm/pool.d/www.conf
+        /etc/php/8.3/fpm/pool.d/www.conf
 RUN mkdir -p ${SCRIPT_ROOT}/config.d /etc/nginx/global /var/www/tt-rss
 
 # Configure Image
@@ -39,7 +39,7 @@ COPY config/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 # forward request and error logs to docker log collector
 RUN ln -sf /dev/stdout /var/log/nginx/access.log \
 	&& ln -sf /dev/stderr /var/log/nginx/error.log \
-	&& ln -sf /dev/stderr /var/log/php8.1-fpm.log
+	&& ln -sf /dev/stderr /var/log/php8.3-fpm.log
 
 # HTTP
 EXPOSE 80/tcp
@@ -69,8 +69,8 @@ ENV TTRSS_PLUGINS="auth_internal, note, nginx_xaccel"
 
 ENV TTRSS_FEED_UPDATE_CHECK=900
 
-ENV OWNER_UID=1000
-ENV OWNER_GID=1000
+ENV OWNER_UID=1001
+ENV OWNER_GID=1001
 
 ENV PHP_WORKER_MAX_CHILDREN=5
 ENV PHP_WORKER_MEMORY_LIMIT=256M

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This Docker image has several assumptions/prerequisites which need to be  fulfil
 1. This image is for domains or sub-domains with **/tt-rss/** in the URL. e.g. **http://reader.mydomain.tld**
 1. MySQL needs to be installed in a separate Docker container.
 1. MySQL needs to be configured and setup **BEFORE** this image is deployed (explained below).
-1. If a previous MySQL instance is used and and old TT-RSS instance was using PHP 7.x then a "Data Fix" will need to be applied to the database as this image used PHP 8.1 and generates JSON differently. Failure to "Data Fix" the database could result in duplicate posts appearing in TT-RSS (explained below)
+1. If a previous MySQL instance is used and and old TT-RSS instance was using PHP 7.x then a "Data Fix" will need to be applied to the database as this image used PHP 8.3 and generates JSON differently. Failure to "Data Fix" the database could result in duplicate posts appearing in TT-RSS (explained below)
 
 ## MySQL Setup
 

--- a/app/startup.sh
+++ b/app/startup.sh
@@ -80,11 +80,11 @@ done
 # Configure PHP
 echo "Setting PHP memory_limit to ${PHP_WORKER_MEMORY_LIMIT}"
 sed -i.bak "s/^\(memory_limit\) = \(.*\)/\1 = ${PHP_WORKER_MEMORY_LIMIT}/" \
-	/etc/php/8.1/fpm/php.ini
+	/etc/php/8.3/fpm/php.ini
 
 echo "Setting PHP pm.max_children to ${PHP_WORKER_MAX_CHILDREN}"
 sed -i.bak "s/^\(pm.max_children\) = \(.*\)/\1 = ${PHP_WORKER_MAX_CHILDREN}/" \
-	/etc/php/8.1/fpm/pool.d/www.conf
+	/etc/php/8.3/fpm/pool.d/www.conf
 
 # Update schema if necessary
 sudo -Eu app ${TTRSS_PHP_EXECUTABLE} $DST_DIR/update.php --update-schema=force-yes

--- a/config/php.conf
+++ b/config/php.conf
@@ -2,7 +2,7 @@
 location ~* \.php$ {
     fastcgi_index   index.php;
     #fastcgi_pass    127.0.0.1:9000;
-    fastcgi_pass    unix:/var/run/php/php8.1-fpm.sock;
+    fastcgi_pass    unix:/var/run/php/php8.3-fpm.sock;
     include         /etc/nginx/fastcgi_params;
     fastcgi_param   SCRIPT_FILENAME    $document_root$fastcgi_script_name;
     fastcgi_param   SCRIPT_NAME        $fastcgi_script_name;

--- a/config/supervisord.conf
+++ b/config/supervisord.conf
@@ -17,7 +17,7 @@ stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 
 [program:php-fpm]
-command=/bin/bash -c "mkdir -p /var/run/php && php-fpm8.1 --nodaemonize --fpm-config /etc/php/8.1/fpm/php-fpm.conf"
+command=/bin/bash -c "mkdir -p /var/run/php && php-fpm8.3 --nodaemonize --fpm-config /etc/php/8.3/fpm/php-fpm.conf"
 autostart=true
 autorestart=true
 stdout_logfile=/dev/stdout


### PR DESCRIPTION
A recent TT-RSS update requires PHP 8.2+

https://git.tt-rss.org/fox/tt-rss.git/commit/?id=cd2c10f9f71409df24fc74c1bbd7d5ddbf48d991

`ubuntu:jammy` only has PHP 8.1.

This changes to `ubuntu:noble` (24) and PHP 8.3 (which is also used in the [official Dockerfile](https://git.tt-rss.org/fox/tt-rss.git/commit/?id=7883f024e7f0c2262256be310044c7ceb2ff3247))